### PR TITLE
Do not apply obligatory "backgroundColor: white"

### DIFF
--- a/src/components/PullToRefresh.tsx
+++ b/src/components/PullToRefresh.tsx
@@ -183,8 +183,7 @@ export class PullToRefresh extends React.Component<PullToRefreshProps, PullToRef
             overflow: "hidden",
             WebkitOverflowScrolling: "touch",
             position: "relative",
-            zIndex: 1,
-            backgroundColor: "white",
+            zIndex: 1
         };
 
         return (


### PR DESCRIPTION
Applied background color influences divs inside the menu, which is not always desired effect.
Hardcoding inline styles instead of classes is not a good idea.