### PR TITLE
Added onlyRefreshAtTop to PullToRefresh component

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ or
 |onRefresh|Promise|true|
 |triggerHeight|number|false|
 |backgroundColor|string|false|
+|onlyRefreshAtTop|boolean|false|
 
 ## Usage
 
@@ -55,6 +56,7 @@ import {PullDownContent, ReleaseContent, RefreshContent} from "react-js-pull-to-
   onRefresh={this.onRefresh}
   triggerHeight={50}
   backgroundColor='white'
+  onlyRefreshAtTop={true}
 >
   <div style={{height: '150vh', textAlign: 'center'}}>
     <div>PullToRefresh</div>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Pull to refresh with react
 [![npm version](https://badge.fury.io/js/react-js-pull-to-refresh.svg)](https://badge.fury.io/js/react-js-pull-to-refresh)
 [![license](https://img.shields.io/github/license/echoulen/react-js-pull-to-refresh.svg)](https://opensource.org/licenses/MIT)
 [![codebeat badge](https://codebeat.co/badges/3be54568-d7c5-4cc2-b5a4-8eae143b4dbf)](https://codebeat.co/projects/github-com-echoulen-react-pull-to-refresh-master)
+[![size](https://badgen.net/bundlephobia/minzip/react-js-pull-to-refresh)](https://bundlephobia.com/result?p=react-js-pull-to-refresh@1.2.1)
 
 ![](https://media.giphy.com/media/xT1R9LCrbpOJ4J7HoI/giphy.gif)
 

--- a/src/components/PullToRefresh.tsx
+++ b/src/components/PullToRefresh.tsx
@@ -8,6 +8,7 @@ export interface PullToRefreshProps {
     onRefresh: () => Promise<any>;
     triggerHeight?: number;
     backgroundColor?: string;
+    onlyRefreshAtTop?: boolean;
 }
 
 export interface PullToRefreshState {
@@ -78,7 +79,11 @@ export class PullToRefresh extends React.Component<PullToRefreshProps, PullToRef
     }
 
     private onTouchStart(e) {
-        const {triggerHeight = 40} = this.props;
+        const {triggerHeight = 40, onlyRefreshAtTop} = this.props;
+        if (onlyRefreshAtTop && this.container.getBoundingClientRect().top < 0) {
+          return;
+        }
+
         this.startY = e["pageY"] || e.touches[0].pageY;
         this.currentY = this.startY;
         const top = this.container.getBoundingClientRect().top || this.container.getBoundingClientRect().y || 0;


### PR DESCRIPTION
Added optional / non-breaking prop to component.
This will only allow the user to pull-to-refresh when the main component is scrolled to the top.
If not used, the component will behave as usual