### PR TITLE
Added id’s to main div’s for css access in certain situations

### DIFF
--- a/__tests__/components/__snapshots__/PullToRefresh.spec.tsx.snap
+++ b/__tests__/components/__snapshots__/PullToRefresh.spec.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`PullToRefresh spec App shows PullToRefresh 1`] = `
 <div
+  id="ptr-parent"
   style={
     Object {
       "WebkitOverflowScrolling": "touch",
@@ -14,6 +15,7 @@ exports[`PullToRefresh spec App shows PullToRefresh 1`] = `
   }
 >
   <div
+    id="ptr-pull-down"
     style={
       Object {
         "left": 0,
@@ -30,6 +32,7 @@ exports[`PullToRefresh spec App shows PullToRefresh 1`] = `
     </div>
   </div>
   <div
+    id="ptr-container"
     style={
       Object {
         "WebkitOverflowScrolling": "touch",

--- a/src/components/PullToRefresh.tsx
+++ b/src/components/PullToRefresh.tsx
@@ -190,7 +190,7 @@ export class PullToRefresh extends React.Component<PullToRefreshProps, PullToRef
             visibility: startInvisible ? "hidden" : "visible",
         };
         return (
-            <div style={contentStyle} ref={this.pullDownRef}>
+            <div id="ptr-pull-down" style={contentStyle} ref={this.pullDownRef}>
                 {content}
             </div>
         );
@@ -211,9 +211,9 @@ export class PullToRefresh extends React.Component<PullToRefreshProps, PullToRef
         }
 
         return (
-            <div style={containerStyle}>
+            <div id="ptr-parent" style={containerStyle}>
                 {this.renderPullDownContent()}
-                <div ref={this.containerRef} style={containerStyle}>
+                <div id="ptr-container" ref={this.containerRef} style={containerStyle}>
                     {this.props.children}
                 </div>
             </div>


### PR DESCRIPTION
Have certain situations where children of the ptr are sticky, and overflow being hidden breaks it.
For now would it be ok to have div id's for custom css options?